### PR TITLE
Made loggers configurable.

### DIFF
--- a/Bin/Debug/settings-template.json
+++ b/Bin/Debug/settings-template.json
@@ -11,14 +11,26 @@
             "ApiKey":"Bot specific apiKey",
             "DisplayName":"TestBot",
             "ChatResponse":"Hi there bro",
-            "logFile": "TestBot.log",
             "BotControlClass": "SteamBot.SimpleUserHandler",
             "MaximumTradeTime":180,
             "MaximumActionGap":30,
             "DisplayNamePrefix":"[AutomatedBot] ",
             "TradePollingInterval":800,
-            "ConsoleLogLevel":"Success",
-            "FileLogLevel":"Info",
+            "Loggers": [
+                {
+                    "LoggerType": "SteamBot.Logging.ConsoleLogger",
+                    "Params": { 
+                        "LogLevel": "Info"
+                    }
+                },
+                {
+                    "LoggerType": "SteamBot.Logging.FileLogger",
+                    "Params": {
+                        "LogLevel": "Info",
+                        "LogFile": "TestBot.log"
+                    }
+                }
+            ],
             "AutoStart": "true"
         }
     ]

--- a/SteamBot/BotManager.cs
+++ b/SteamBot/BotManager.cs
@@ -8,6 +8,7 @@ using System.Windows.Forms;
 using Newtonsoft.Json;
 using SteamKit2;
 using SteamBot.Logging;
+using System.Dynamic;
 
 namespace SteamBot
 {
@@ -52,8 +53,12 @@ namespace SteamBot
                 return false;
 
             useSeparateProcesses = ConfigObject.UseSeparateProcesses;
-
-            mainLog = new Log(null, true, new ConsoleLogger(LogLevel.Info), new FileLogger(LogLevel.Info, ConfigObject.MainLog));
+            string json = "{" +
+            "\"LogLevel\": \"Info\"," +
+            "\"LogFile\": \"" + ConfigObject.MainLog + "\"" +
+            "}";
+            dynamic LogParams = JsonConvert.DeserializeObject<dynamic>(json);
+            mainLog = new Log(null, true, new ConsoleLogger(LogParams), new FileLogger(LogParams));
 
             for (int i = 0; i < ConfigObject.Bots.Length; i++)
             {

--- a/SteamBot/BotManager.cs
+++ b/SteamBot/BotManager.cs
@@ -52,7 +52,7 @@ namespace SteamBot
                 return false;
 
             useSeparateProcesses = ConfigObject.UseSeparateProcesses;
-            JObject LogParams = JsonConvert.DeserializeObject<JObject>("{" +
+            JObject LogParams = JObject.Parse("{" +
             "\"LogLevel\": \"Info\"," +
             "\"LogFile\": \"" + ConfigObject.MainLog + "\"" +
             "}");

--- a/SteamBot/BotManager.cs
+++ b/SteamBot/BotManager.cs
@@ -4,11 +4,10 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using System.Windows.Forms;
 using Newtonsoft.Json;
-using SteamKit2;
+using Newtonsoft.Json.Linq;
 using SteamBot.Logging;
-using System.Dynamic;
+using SteamKit2;
 
 namespace SteamBot
 {
@@ -53,11 +52,10 @@ namespace SteamBot
                 return false;
 
             useSeparateProcesses = ConfigObject.UseSeparateProcesses;
-            string json = "{" +
+            JObject LogParams = JsonConvert.DeserializeObject<JObject>("{" +
             "\"LogLevel\": \"Info\"," +
             "\"LogFile\": \"" + ConfigObject.MainLog + "\"" +
-            "}";
-            dynamic LogParams = JsonConvert.DeserializeObject<dynamic>(json);
+            "}");
             mainLog = new Log(null, true, new ConsoleLogger(LogParams), new FileLogger(LogParams));
 
             for (int i = 0; i < ConfigObject.Bots.Length; i++)

--- a/SteamBot/Configuration.cs
+++ b/SteamBot/Configuration.cs
@@ -4,11 +4,18 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace SteamBot
 {
     public class Configuration
     {
+        public class Loggers
+        {
+            public string LoggerType { get; set; }
+            public JObject Params { get; set; }
+        }
+
         public static Configuration LoadConfiguration (string filename)
         {
             TextReader reader = new StreamReader(filename);
@@ -122,15 +129,13 @@ namespace SteamBot
             public string ApiKey { get; set; }
             public string DisplayName { get; set; }
             public string ChatResponse { get; set; }
-            public string LogFile { get; set; }
             public string BotControlClass { get; set; }
             public int MaximumTradeTime { get; set; }
             public int MaximumActionGap { get; set; }
             public string DisplayNamePrefix { get; set; }
             public int TradePollingInterval { get; set; }
-            public string ConsoleLogLevel { get; set; }
-            public string FileLogLevel { get; set; }
             public ulong[] Admins { get; set; }
+            public Loggers[] Loggers { get; set; }
 
             // Depreciated configuration options
             public string LogLevel { get; set; }

--- a/SteamBot/Logging/ConsoleLogger.cs
+++ b/SteamBot/Logging/ConsoleLogger.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using Newtonsoft.Json.Linq;
 
 namespace SteamBot.Logging
 {
@@ -9,9 +7,11 @@ namespace SteamBot.Logging
     {
         private ConsoleColor DefaultConsoleColor;
 
-        public ConsoleLogger(LogLevel outputLevel, ConsoleColor defaultColor = ConsoleColor.White) : base(outputLevel)
+        public ConsoleLogger(JObject logParams)
+            : base(logParams)
         {
-            DefaultConsoleColor = defaultColor;
+            if (logParams["DefaultColor"] == null || !Enum.TryParse<ConsoleColor>((string)logParams["DefaultColor"], out DefaultConsoleColor))
+                DefaultConsoleColor = ConsoleColor.White;
             Console.ForegroundColor = DefaultConsoleColor;
         }
 

--- a/SteamBot/Logging/FileLogger.cs
+++ b/SteamBot/Logging/FileLogger.cs
@@ -36,7 +36,6 @@ namespace SteamBot.Logging
         public void Dispose()
         {
             FileDispose();
-            GC.SuppressFinalize(this);
         }
 
         private void FileDispose()

--- a/SteamBot/Logging/FileLogger.cs
+++ b/SteamBot/Logging/FileLogger.cs
@@ -39,7 +39,7 @@ namespace SteamBot.Logging
             GC.SuppressFinalize(this);
         }
 
-        public void FileDispose()
+        private void FileDispose()
         {
             if (!Disposed)
             {

--- a/SteamBot/Logging/Log.cs
+++ b/SteamBot/Logging/Log.cs
@@ -32,7 +32,7 @@ namespace SteamBot.Logging
 
         ~Log()
         {
-            Dispose(false);
+            LogDispose();
         }
 
         private void CallLogMessage(LogLevel level, string data, params object[] formatParams)
@@ -99,18 +99,15 @@ namespace SteamBot.Logging
 
         public void Dispose()
         {
-            Dispose(true);
+            LogDispose();
         }
 
-        private void Dispose(bool disposing)
+        private void LogDispose()
         {
             if (!Disposed)
             {
-                if (disposing)
-                {
                     foreach (IDisposable disposableLogger in LoggerObjects.OfType<IDisposable>())
                         disposableLogger.Dispose();
-                }
                 LoggerObjects.Clear();
                 LoggerObjects = null;
                 Disposed = true;

--- a/SteamBot/Logging/Log.cs
+++ b/SteamBot/Logging/Log.cs
@@ -100,7 +100,6 @@ namespace SteamBot.Logging
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         private void Dispose(bool disposing)

--- a/SteamBot/Logging/Log.cs
+++ b/SteamBot/Logging/Log.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 
 namespace SteamBot.Logging
@@ -29,6 +28,11 @@ namespace SteamBot.Logging
                 this.OnLog += logger.LogMessage;
             }
             ShowBotName = true;
+        }
+
+        ~Log()
+        {
+            Dispose(false);
         }
 
         private void CallLogMessage(LogLevel level, string data, params object[] formatParams)
@@ -95,10 +99,22 @@ namespace SteamBot.Logging
 
         public void Dispose()
         {
-            Disposed = true;
-            foreach (IDisposable logger in LoggerObjects.OfType<IDisposable>())
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        public void Dispose(bool disposing)
+        {
+            if (!Disposed)
             {
-                logger.Dispose();
+                if (disposing)
+                {
+                    foreach (IDisposable disposableLogger in LoggerObjects.OfType<IDisposable>())
+                        disposableLogger.Dispose();
+                }
+                LoggerObjects.Clear();
+                LoggerObjects = null;
+                Disposed = true;
             }
         }
     }

--- a/SteamBot/Logging/Log.cs
+++ b/SteamBot/Logging/Log.cs
@@ -103,7 +103,7 @@ namespace SteamBot.Logging
             GC.SuppressFinalize(this);
         }
 
-        public void Dispose(bool disposing)
+        private void Dispose(bool disposing)
         {
             if (!Disposed)
             {

--- a/SteamBot/Logging/Log.cs
+++ b/SteamBot/Logging/Log.cs
@@ -106,8 +106,8 @@ namespace SteamBot.Logging
         {
             if (!Disposed)
             {
-                    foreach (IDisposable disposableLogger in LoggerObjects.OfType<IDisposable>())
-                        disposableLogger.Dispose();
+                foreach (IDisposable disposableLogger in LoggerObjects.OfType<IDisposable>())
+                    disposableLogger.Dispose();
                 LoggerObjects.Clear();
                 LoggerObjects = null;
                 Disposed = true;

--- a/SteamBot/Logging/LoggerBase.cs
+++ b/SteamBot/Logging/LoggerBase.cs
@@ -1,7 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
+using Newtonsoft.Json.Linq;
 
 namespace SteamBot.Logging
 {
@@ -51,11 +50,12 @@ namespace SteamBot.Logging
         /// <summary>
         /// The min logging output level for this class.
         /// </summary>
-        public LogLevel OutputLevel { get; set; }
+        public LogLevel OutputLevel;
 
-        public LoggerBase(LogLevel outputLevel)
+        public LoggerBase(JObject logParams)
         {
-            OutputLevel = outputLevel;
+            if (!Enum.TryParse<LogLevel>((string)logParams["LogLevel"], out OutputLevel))
+                OutputLevel = LogLevel.Info;
         }
 
         private string BotName(LoggerParams lParams)

--- a/SteamBot/Logging/LoggingUtils.cs
+++ b/SteamBot/Logging/LoggingUtils.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace SteamBot.Logging
+﻿namespace SteamBot.Logging
 {
     public enum LogLevel
     {

--- a/SteamBot/UserHandler.cs
+++ b/SteamBot/UserHandler.cs
@@ -1,12 +1,9 @@
 ﻿using System;
 using System.Linq;
-using System.Security.AccessControl;
-using System.Threading;
 using System.Threading.Tasks;
-using System.Windows.Forms;
+using SteamBot.Logging;
 using SteamKit2;
 using SteamTrade;
-using SteamBot.Logging;
 using SteamTrade.TradeOffer;
 
 namespace SteamBot
@@ -179,10 +176,6 @@ namespace SteamBot
         public virtual void OnBotCommand(string command)
         {
 
-        }
-
-        public virtual void OnBotCreated()
-        {
         }
 
         /// <summary>


### PR DESCRIPTION
Alright, this allows for loggers to be added to the bot and easily be usable by userhandlers.  
Side note: BotManager is only limited to Console and File logging.  
Another side note: For Log and FileLogger, I added a finalization method to call Dispose just to make sure that the log file is not still open even when it shouldn't be.